### PR TITLE
docs: ads-api campaigns use LINE_ITEM budget optimization only

### DIFF
--- a/x-ads-api/campaign-management/reference.mdx
+++ b/x-ads-api/campaign-management/reference.mdx
@@ -954,7 +954,7 @@ Retrieve details for some or all campaigns associated with the current account.
       "data": [
         {
           "name": "test",
-          "budget_optimization": "CAMPAIGN",
+          "budget_optimization": "LINE_ITEM",
           "reasons_not_servable": [
             "PAUSED_BY_ADVERTISER",
             "INCOMPLETE"
@@ -965,7 +965,7 @@ Retrieve details for some or all campaigns associated with the current account.
           "daily_budget_amount_local_micro": 10000000,
           "funding_instrument_id": "lygyi",
           "duration_in_days": null,
-          "standard_delivery": false,
+          "standard_delivery": null,
           "total_budget_amount_local_micro": null,
           "id": "8wku2",
           "entity_status": "PAUSED",
@@ -1015,7 +1015,7 @@ Retrieve a specific campaign associated with the current account.
       },
       "data": {
         "name": "test",
-        "budget_optimization": "CAMPAIGN",
+        "budget_optimization": "LINE_ITEM",
         "reasons_not_servable": [
           "PAUSED_BY_ADVERTISER",
           "INCOMPLETE"
@@ -1026,7 +1026,7 @@ Retrieve a specific campaign associated with the current account.
         "daily_budget_amount_local_micro": 10000000,
         "funding_instrument_id": "lygyi",
         "duration_in_days": null,
-        "standard_delivery": false,
+        "standard_delivery": null,
         "total_budget_amount_local_micro": null,
         "id": "8wku2",
         "entity_status": "PAUSED",
@@ -1061,9 +1061,9 @@ Create a new campaign associated with the current account.
   The name for the campaign. Maximum length: 255 characters.
 </ParamField>
 
-<ParamField query="budget_optimization" type="string" default="CAMPAIGN">
+<ParamField query="budget_optimization" type="string" default="LINE_ITEM">
   Select the type of budget optimization to be applied.<br/><br/>
-  Possible values: `CAMPAIGN`, `LINE_ITEM`
+  Possible values: `LINE_ITEM`
 </ParamField>
 
 <ParamField query="daily_budget_amount_local_micro" type="long" optional>
@@ -1081,7 +1081,7 @@ Create a new campaign associated with the current account.
 </ParamField>
 
 <ParamField query="standard_delivery" type="boolean" default="true">
-  Enable standard or accelerated delivery. See [Budget Pacing](/x-ads-api/campaign-management/reference#budget-pacing) for more information on standard versus accelerated delivery. Only available when `budget_optimization` is set to `CAMPAIGN`.
+  **Deprecated at the campaign level.** Since budget optimization is always `LINE_ITEM`, standard versus accelerated delivery is configured on the line item via its `standard_delivery` parameter. See [Budget Pacing](/x-ads-api/campaign-management/reference#budget-pacing) for more information.
 </ParamField>
 
 <ParamField query="total_budget_amount_local_micro" type="long" optional>
@@ -1090,7 +1090,7 @@ Create a new campaign associated with the current account.
 
 **Example Request**
 
-`POST https://ads-api.x.com/12/accounts/18ce54d4x5t/campaigns?funding_instrument_id=lygyi&name=demo&daily_budget_amount_local_micro=140000000&entity_status=PAUSED&budget_optimization=CAMPIAGN&standard_delivery=false`
+`POST https://ads-api.x.com/12/accounts/18ce54d4x5t/campaigns?funding_instrument_id=lygyi&name=demo&daily_budget_amount_local_micro=140000000&entity_status=PAUSED&budget_optimization=LINE_ITEM`
 
 **Example Response**
 
@@ -1099,17 +1099,16 @@ Create a new campaign associated with the current account.
       "request": {
         "params": {
           "name": "demo",
-          "budget_optimization": "CAMPAIGN",
+          "budget_optimization": "LINE_ITEM",
           "daily_budget_amount_local_micro": 140000000,
           "funding_instrument_id": "lygyi",
-          "standard_delivery": false,
           "entity_status": "PAUSED",
           "account_id": "18ce54d4x5t"
         }
       },
       "data": {
         "name": "demo",
-        "budget_optimization": "CAMPAIGN",
+        "budget_optimization": "LINE_ITEM",
         "reasons_not_servable": [
           "PAUSED_BY_ADVERTISER",
           "INCOMPLETE"
@@ -1120,7 +1119,7 @@ Create a new campaign associated with the current account.
         "daily_budget_amount_local_micro": 140000000,
         "funding_instrument_id": "lygyi",
         "duration_in_days": null,
-        "standard_delivery": false,
+        "standard_delivery": null,
         "total_budget_amount_local_micro": null,
         "id": "hwtbm",
         "entity_status": "PAUSED",
@@ -1178,7 +1177,7 @@ Batch API responses return an ordered collection of items. Otherwise, they are i
           "funding_instrument_id":"lygyi",
           "daily_budget_amount_local_micro":140000000,
           "entity_status":"PAUSED",
-          "budget_optimization":"CAMPAIGN"
+          "budget_optimization":"LINE_ITEM"
         }
       }
     ]
@@ -1191,7 +1190,7 @@ Batch API responses return an ordered collection of items. Otherwise, they are i
       "data": [
         {
           "name": "batch campaigns",
-          "budget_optimization": "CAMPAIGN",
+          "budget_optimization": "LINE_ITEM",
           "reasons_not_servable": [
             "PAUSED_BY_ADVERTISER",
             "INCOMPLETE"
@@ -1202,7 +1201,7 @@ Batch API responses return an ordered collection of items. Otherwise, they are i
           "daily_budget_amount_local_micro": 140000000,
           "funding_instrument_id": "lygyi",
           "duration_in_days": null,
-          "standard_delivery": false,
+          "standard_delivery": null,
           "total_budget_amount_local_micro": null,
           "id": "8yn7m",
           "entity_status": "PAUSED",
@@ -1220,7 +1219,7 @@ Batch API responses return an ordered collection of items. Otherwise, they are i
             "funding_instrument_id": "lygyi",
             "daily_budget_amount_local_micro": 140000000,
             "entity_status": "PAUSED",
-            "budget_optimization":"CAMPAIGN",
+            "budget_optimization":"LINE_ITEM",
             "account_id": "18ce54d4x5t"
           },
           "operation_type": "Create"
@@ -1245,9 +1244,9 @@ Update the specified campaign associated with the current account.
   A reference to the campaign you are operating with in the request.
 </ParamField>
 
-<ParamField query="budget_optimization" type="string" default="CAMPAIGN">
+<ParamField query="budget_optimization" type="string" default="LINE_ITEM">
   Select the type of budget optimization to be applied.<br/><br/>
-  Possible values: `CAMPAIGN`, `LINE_ITEM`
+  Possible values: `LINE_ITEM`
 </ParamField>
 
 <ParamField query="daily_budget_amount_local_micro" type="long" optional>
@@ -1269,7 +1268,7 @@ Update the specified campaign associated with the current account.
 </ParamField>
 
 <ParamField query="standard_delivery" type="boolean" default="true">
-  Enable standard or accelerated delivery. See [Budget Pacing](/x-ads-api/campaign-management/reference#budget-pacing) for more information on standard versus accelerated delivery. Only available when `budget_optimization` is set to `CAMPAIGN`.
+  **Deprecated at the campaign level.** Since budget optimization is always `LINE_ITEM`, standard versus accelerated delivery is configured on the line item via its `standard_delivery` parameter. See [Budget Pacing](/x-ads-api/campaign-management/reference#budget-pacing) for more information.
 </ParamField>
 
 <ParamField query="total_budget_amount_local_micro" type="long" optional>
@@ -1293,7 +1292,7 @@ Update the specified campaign associated with the current account.
       },
       "data": {
         "name": "test",
-        "budget_optimization": "CAMPAIGN",
+        "budget_optimization": "LINE_ITEM",
         "reasons_not_servable": [
           "PAUSED_BY_ADVERTISER",
           "INCOMPLETE"
@@ -1304,7 +1303,7 @@ Update the specified campaign associated with the current account.
         "daily_budget_amount_local_micro": 140000000,
         "funding_instrument_id": "lygyi",
         "duration_in_days": null,
-        "standard_delivery": false,
+        "standard_delivery": null,
         "total_budget_amount_local_micro": null,
         "id": "8wku2",
         "entity_status": "PAUSED",
@@ -1351,7 +1350,7 @@ Delete the specified campaign belonging to the current account.
       },
       "data": {
         "name": "test",
-        "budget_optimization": "CAMPAIGN",
+        "budget_optimization": "LINE_ITEM",
         "reasons_not_servable": [],
         "servable": null,
         "purchase_order_number": null,
@@ -1359,7 +1358,7 @@ Delete the specified campaign belonging to the current account.
         "daily_budget_amount_local_micro": 140000000,
         "funding_instrument_id": "lygyi",
         "duration_in_days": null,
-        "standard_delivery": false,
+        "standard_delivery": null,
         "total_budget_amount_local_micro": null,
         "id": "8yn7m",
         "entity_status": "PAUSED",


### PR DESCRIPTION
## Summary
Updates the Campaign Management API reference to reflect that campaigns only support `LINE_ITEM` budget optimization (`CAMPAIGN`-level budget optimization is no longer supported).

- `budget_optimization`: documents `LINE_ITEM` as the only possible value and the default (was `CAMPAIGN`), in both the create (`POST`) and update (`PUT`) parameter tables.
- `standard_delivery`: marked deprecated at the campaign level — standard vs. accelerated delivery is now configured on the line item via its own `standard_delivery` parameter.
- Example requests/responses updated to match: `budget_optimization` `CAMPAIGN` → `LINE_ITEM`, campaign-level `standard_delivery` → `null`, and dropped `standard_delivery` from the create example request. Also fixed the `CAMPIAGN` typo in the example URL.

This aligns the docs with the X Ads Manager UI, which always sends `budget_optimization: LINE_ITEM` and sets pacing/`standard_delivery` per line item.

## Scope
Single file: `x-ads-api/campaign-management/reference.mdx` (22 insertions, 23 deletions). No content changes outside the campaign endpoints; the unrelated `entity_type` enum and line-item `standard_delivery` docs are untouched.

## Test plan
- [ ] Verify the rendered `budget_optimization` and `standard_delivery` parameter tables on the create/update campaign sections
- [ ] Confirm example JSON blocks still parse and read consistently

Made with [Cursor](https://cursor.com)