### PR TITLE
Remove reply-quote validation detail from the cryptography primer

### DIFF
--- a/xchat/cryptography-primer.mdx
+++ b/xchat/cryptography-primer.mdx
@@ -184,8 +184,6 @@ If anything in the signed content changes, verification fails. Of course, this g
 
 **In your app.** The XDK signs when you encrypt and verifies when you decrypt. Rejection happens at both ends: X Chat itself rejects events it cannot verify, and the XDK does the same on receipt, **mandatory by default** (disabling this is not recommended). Details: [Chat XDK](/xchat/xchat-xdk).
 
-Signatures also cover quoted content. A reply embeds the raw **signed** original message it quotes; when the Chat XDK decrypts the reply, it verifies that embedded original and compares the quote against it, reporting the outcome as `reply_preview_validation` (`Valid` / `Invalid`). An `Invalid` outcome means the quote does not match the signed original—treat the quoted material as untrusted, even though the reply itself is verified separately—so no participant can attribute fabricated words to another.
-
 ### Signed state changes (action signatures)
 
 Messages are not the only thing signed. Every change to a conversation (creating a group, adding members, rotating a key) must also carry **action signatures**: the sender signs a payload describing exactly what the change does, and the API rejects requests where these are missing or malformed. The XDK produces them for you.


### PR DESCRIPTION
Follow-up to #273. reply-quote validation edit got merged together with prev commit. Not necessary in this cryptography primer, already documented in the [Chat XDK reference](https://docs.x.com/xchat/xchat-xdk) and in [Troubleshooting](https://docs.x.com/xchat/troubleshooting), where the field-level detail belongs.